### PR TITLE
Implement the save word functionality

### DIFF
--- a/src/api/mock-server/data/set.data.ts
+++ b/src/api/mock-server/data/set.data.ts
@@ -7,6 +7,7 @@ export const setData = {
     "relearning": 0,
     "graduated": 0
   },
+  "protected": false,
   "words": [
     {
       "id": "62654ed22b1dda1589570b7d",

--- a/src/api/mock-server/data/sets-search.data.ts
+++ b/src/api/mock-server/data/sets-search.data.ts
@@ -1,65 +1,66 @@
-export const setSearchData = {
-  "sets": [
-    {
-      "id": "set_id_0",
-      "title": "Set 0",
-      "progress": {
-        "learning": 2,
-        "relearning": 0,
-        "graduated": 0
-      },
-      "words": [
-        {
-          "id": "0_1",
-          "word": "word 1",
-          "meaning": "meaning 1"
-        },
-        {
-            "id": "0_2",
-            "word": "word 2",
-            "meaning": "meaning 2"
-        },
-      ]
-    },
-    {
-      "id": "set_id_1",
-      "title": "Set 1",
-      "progress": {
-        "learning": 0,
-        "relearning": 1,
-        "graduated": 1
-      },
-      "words": [
-        {
-          "id": "1_1",
-          "word": "word 3",
-          "meaning": "meaning 3"
-        },
-        {
-            "id": "1_2",
-            "word": "word 4",
-            "meaning": "meaning 4"
-        },
-      ]
-    },
-  ],
-  "userWords": {
+export const setSearchData = [
+  {
+    "id": "set_id_2",
+    "title": "Saved words",
+    "protected": true,
     "progress": {
-      "learning": 1,
-      "relearning": 0,
+      "learning": 0,
+      "relearning": 1,
       "graduated": 1
     },
     "words": [
       {
-        "id": "0_1",
+        "id": "2_1",
         "word": "word 5",
         "meaning": "meaning 5"
       },
       {
-          "id": "0_2",
+          "id": "2_2",
           "word": "word 6",
           "meaning": "meaning 6"
       },
     ]
-  }
-}
+  },
+  {
+    "id": "set_id_0",
+    "title": "Set 0",
+    "progress": {
+      "learning": 2,
+      "relearning": 0,
+      "graduated": 0
+    },
+    "words": [
+      {
+        "id": "0_1",
+        "word": "word 1",
+        "meaning": "meaning 1"
+      },
+      {
+          "id": "0_2",
+          "word": "word 2",
+          "meaning": "meaning 2"
+      },
+    ]
+  },
+  {
+    "id": "set_id_1",
+    "title": "Set 1",
+    "progress": {
+      "learning": 0,
+      "relearning": 1,
+      "graduated": 1
+    },
+    "words": [
+      {
+        "id": "1_1",
+        "word": "word 3",
+        "meaning": "meaning 3"
+      },
+      {
+          "id": "1_2",
+          "word": "word 4",
+          "meaning": "meaning 4"
+      },
+    ]
+  },
+]

--- a/src/api/mock-server/sets.ts
+++ b/src/api/mock-server/sets.ts
@@ -4,10 +4,7 @@ import { setData } from './data/set.data';
 import { setSearchData } from './data/sets-search.data';
 import { setsData } from './data/sets.data';
 
-const searchItems = {
-  sets: [ ...setSearchData.sets ],
-  userWords: { ...setSearchData.userWords },
-}
+let searchItems = [ ...setSearchData ]
 
 export const mocksSets = [
   rest.get('/api/v1/sets/progress', (req, res, ctx) => {
@@ -50,6 +47,16 @@ export const mocksSets = [
     )
   }),
 
+  rest.get(`/api/v1/sets/set_id_2`, (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({
+        status: 200,
+        data: setData,
+      })
+    )
+  }),
+
 
   rest.get(`/api/v1/sets/error`, (req, res, ctx) => {
     return res(
@@ -69,6 +76,7 @@ export const mocksSets = [
         data: {
           "id": "empty",
           "title": "Empty Set",
+          "protected": false,
           "progress": {
             "learning": 0,
             "relearning": 0,
@@ -106,10 +114,7 @@ export const mocksSets = [
       ctx.status(200),
       ctx.json({
         status: 200,
-        data: {
-          'sets': [],
-          'userWords': undefined,
-        },
+        data: [],
       })
     )
   }),
@@ -126,7 +131,7 @@ export const mocksSets = [
   }),
 
   rest.delete(`/api/v1/sets/set_id_0`, (req, res, ctx) => {
-    searchItems.sets = searchItems.sets.filter(item => item.id !== 'set_id_0')
+    searchItems = searchItems.filter(item => item.id !== 'set_id_0')
 
     return res(
       ctx.status(404),
@@ -148,8 +153,7 @@ export const mocksSets = [
   }),
 
   rest.get(`/api/v1/sets/restoreSearchData`, (req, res, ctx) => {
-    searchItems.sets = [ ...setSearchData.sets ]
-    searchItems.userWords = { ...setSearchData.userWords }
+    searchItems = [ ...setSearchData ];
 
     return res(
       ctx.status(200),

--- a/src/components/sets-masonry/sets-masonry.tsx
+++ b/src/components/sets-masonry/sets-masonry.tsx
@@ -13,14 +13,14 @@ export type MasonryItem = {
   }[];
 }
 
-type Props = {
-  sets: MasonryItem[],
-  icons?: (item: MasonryItem) => JSX.Element[],
-  onClick?: (item: MasonryItem) => void,
+type Props<Item extends MasonryItem> = {
+  sets: Item[],
+  icons?: (item: Item) => JSX.Element[],
+  onClick?: (item: Item) => void,
 }
 
-export const SetsMasonry = ({ sets, icons, onClick }: Props) => {
-  const handleClick = (set: MasonryItem) => {
+export function SetsMasonry<Item extends MasonryItem>({ sets, icons, onClick }: Props<Item>) {
+  const handleClick = (set: Item) => {
     if(onClick) {
       return () => onClick(set);
     }
@@ -29,14 +29,14 @@ export const SetsMasonry = ({ sets, icons, onClick }: Props) => {
   return (
     <Masonry itemWidth={450}>
       {
-        sets.map(({ title, words, progress, id }) => (
+        sets.map((set) => (
           <SetCard 
-            key={id}
-            title={title}
-            progress={progress} 
-            data={words}
-            icons={icons ? icons({ title, words, progress, id }) : []}
-            onClick={handleClick({ title, words, progress, id })}
+            key={set.id}
+            title={set.title}
+            progress={set.progress} 
+            data={set.words}
+            icons={icons ? icons(set) : []}
+            onClick={handleClick(set)}
           />
         ))
       }

--- a/src/pages/app/set-list/set-list.test.tsx
+++ b/src/pages/app/set-list/set-list.test.tsx
@@ -1,45 +1,80 @@
 import * as editSetSlice from '../../../redux/slices/edit-set/edit-set';
 import * as DeleteIcon from '@mui/icons-material/Delete';
 import * as EditIcon from '@mui/icons-material/Edit';
+import * as useResize from "../../../utils/use-resize/use-resize";
+import axios from 'axios';
+import SetList from "./set-list";
+import { useEffect } from 'react';
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { TestingContainer } from "../../../utils/test-utils/testing-container";
-import SetList from "./set-list";
 import { mockIcon, MockIcon } from '../../../utils/mocks/icon-mock';
-import axios from 'axios';
+
+const mockUseResize = (width: number) => {
+  const events: ((value: number) => void)[] = [];
+  
+  return [
+    (callback: any) => {
+
+      useEffect(() => {
+        callback(width);
+        events.push(callback);
+
+        return () => { 
+          events.splice(events.indexOf(callback), 1);
+        };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      },[]);
+    },
+    (width: number) => {
+      events.forEach(event => event(width));
+    }
+  ] as const;
+};
 
 describe(`SetList`, () => {
   let deleteIcon: MockIcon;
   let editIcon: MockIcon;
+  let useResizeSpy: jest.SpyInstance;
   let editSetOrigin = editSetSlice.editSet;
   let editSetSpy: jest.SpyInstance;
-  let axiosDeleteSpy: jest.SpyInstance;
   let axiosGetSpy: jest.SpyInstance;
-  const axiosDeleteOrigin = axios.delete;
+  let axiosDeleteSpy: jest.SpyInstance;
   const axiosGetOrigin = axios.get;
+  const axiosDeleteOrigin = axios.delete;
 
   beforeAll(() => {
     deleteIcon = mockIcon(DeleteIcon, 'delete icon');
     editIcon = mockIcon(EditIcon, 'edit icon');
+    useResizeSpy = jest.spyOn(useResize, "useResize");
     editSetSpy = jest.spyOn(editSetSlice, 'editSet');
     axiosDeleteSpy = jest.spyOn(axios, 'delete');
     axiosGetSpy = jest.spyOn(axios, 'get');
   });
 
   beforeEach(() => {
+    useResizeSpy.mockClear();
+    
+    const [mock] = mockUseResize(400);
+    useResizeSpy.mockImplementation(mock);
+
     editSetSpy.mockClear();
     editSetSpy.mockImplementation(editSetOrigin);
+
+    axiosGetSpy.mockClear();
+    axiosGetSpy.mockImplementation(axiosGetOrigin);
 
     axiosDeleteSpy.mockClear();
     axiosDeleteSpy.mockImplementation(axiosDeleteOrigin);
 
-    axiosGetSpy.mockClear();
-    axiosGetSpy.mockImplementation(axiosGetOrigin);
   });
 
   afterAll(() => {
     deleteIcon.mockRestore();
     editIcon.mockRestore();
+    useResizeSpy.mockRestore();
     editSetSpy.mockRestore();
+    axiosDeleteSpy.mockRestore();
+    axiosGetSpy.mockRestore();
   });
 
   it(`should render page title`, async () => {
@@ -119,7 +154,7 @@ describe(`SetList`, () => {
 
     expect(screen.getByText('Edit set page')).toBeInTheDocument();
     expect(editSetSpy).toBeCalledTimes(1);
-    expect(editSetSpy).toBeCalledWith('set_id_0');
+    expect(editSetSpy).toBeCalledWith('set_id_2');
   });
 
   it(`should open the 'edit-set' page if the 'New set' button is clicked`, async () => {
@@ -134,6 +169,25 @@ describe(`SetList`, () => {
     expect(screen.getByText('Edit set page')).toBeInTheDocument();
   });
 
+  it(`shouldn't display the delete icon if the set is protected`, async () => {
+    const { wrapper } = TestingContainer();
+    render(<SetList />, { wrapper });
+    
+    await screen.findByText(`Loading please wait...`);
+    await waitFor(() => expect(screen.queryByText('Loading please wait...')).not.toBeInTheDocument());
+    
+    const card = screen.getAllByTestId('card')[0];
+    const deleteIcons = screen.getAllByText('delete icon');
+
+    expect(card).toContainElement(screen.getByText('Saved words'));
+    expect(deleteIcons.length).toBe(2);
+
+    for (const icon of deleteIcons) {
+      expect(card).not.toContainElement(icon);
+    }
+  });
+
+
   describe('Delete dialog', () => {
     it(`should show the delete dialog if an delete icon is clicked`, async () => {
       const { wrapper } = TestingContainer();
@@ -143,7 +197,7 @@ describe(`SetList`, () => {
       await waitFor(() => expect(screen.queryByText('Loading please wait...')).not.toBeInTheDocument());
       
       fireEvent.click(screen.getAllByText('delete icon')[0]);
-  
+
       expect(screen.getByText('Are you sure you want to delete this set?')).toBeInTheDocument();
     })
   

--- a/src/pages/app/set/edit-set/edit-set.test.tsx
+++ b/src/pages/app/set/edit-set/edit-set.test.tsx
@@ -15,6 +15,7 @@ const state = {
       message: '',
     },
     title: 'Set Title',
+    isProtected: false,
     words: [
       {
         type: 'create' as const,
@@ -116,6 +117,16 @@ describe(`EditSet`, () => {
 
     expect(reduxActions['editSet/removeWord']).toEqual(undefined)
   });
+
+  it(`shouldn't display tex set title textbox if the edited set is protected`, async () => {
+    const { wrapper } = TestingContainer(undefined, { editSet: { ...state.editSet, isProtected: true }});
+    render(<EditSet />, { wrapper });
+
+    await waitFor(() => expect(screen.queryByText('Loading please wait...')).not.toBeInTheDocument());
+
+    expect(screen.queryByText(`Edit set's title`)).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue(`Set Title`)).not.toBeInTheDocument();
+  })
 
   it(`should dispatch the setTitle action if the Set title textbox is edited`, async () => {
     const { wrapper, reduxActions } = TestingContainer(undefined, state);
@@ -229,6 +240,7 @@ describe(`EditSet`, () => {
           state: 'success' as const,
           message: '',
         },
+        isProtected: false,
         title: 'Set Title',
         words: [
           {

--- a/src/pages/app/set/edit-set/edit-set.tsx
+++ b/src/pages/app/set/edit-set/edit-set.tsx
@@ -18,7 +18,7 @@ import { generateUsedInText, UsedInInfoIcon } from '../../../../components/used-
 export const EditSet = () => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const { title, words, progress } = useAppSelector(({ editSet }) => editSet);
+  const { isProtected, title, words, progress } = useAppSelector(({ editSet }) => editSet);
   const [ hasError, setHasError ] = useState(false);
 
   useEffect(() => {
@@ -85,22 +85,26 @@ export const EditSet = () => {
       <Header title={title} />
       <Container>
         <Loading timeout={10000} noBackground {...progress}>
-          <StyledTypography align="center" variant="h6">
-            Edit set's title
-          </StyledTypography>
+          
+          { !isProtected && (
+            <>
+              <StyledTypography align="center" variant="h6">
+                Edit set's title
+              </StyledTypography>
 
-          <TextField
-              style={{ width: '100%' }}
-              type="text"
-              label="Set title"
-              variant="outlined"
-              color="primary"
-              fullWidth
-              value={title}
-              onChange={(e) => dispatch(setTitle(e.target.value))}
-          />
-
-
+              <TextField
+                  style={{ width: '100%' }}
+                  type="text"
+                  label="Set title"
+                  variant="outlined"
+                  color="primary"
+                  fullWidth
+                  value={title}
+                  onChange={(e) => dispatch(setTitle(e.target.value))}
+              />
+            </>
+          )}
+          
           { words.map((word) => (
             <EditWord 
               key={word.id}

--- a/src/redux/slices/edit-set/edit-set.test.ts
+++ b/src/redux/slices/edit-set/edit-set.test.ts
@@ -5,6 +5,7 @@ import { WordDataConstructor } from "./edit-set.type";
 const state = {
   id: undefined,
   title: 'New set',
+  isProtected: false,
   words: [
     {
       id: "0_1",
@@ -54,6 +55,7 @@ describe(`editSetSlice`, () => {
         id: undefined,
         title: 'New set',
         words: [],
+        isProtected: false,
         progress: {
           mode: 'loading',
           state: 'loading',
@@ -68,6 +70,7 @@ describe(`editSetSlice`, () => {
           id: undefined,
           title: `new title`,
           words: [],
+          isProtected: false,
           progress: {
             mode: 'loading',
             state: 'loading',
@@ -93,6 +96,7 @@ describe(`editSetSlice`, () => {
         expect(editSetReducer(undefined, { type: `editSet/addWord`, payload: word })).toEqual({
           id: undefined,
           title: 'New set',
+          isProtected: false,
           words: [{
             id: expect.any(String),
             type: 'create',
@@ -118,6 +122,7 @@ describe(`editSetSlice`, () => {
         expect(editSetReducer(state, { type: `editSet/removeWord`, payload: '0_2' })).toEqual({
           id: undefined,
           title: 'New set',
+          isProtected: false,
           words: [
             {
               id: "0_1",
@@ -230,6 +235,7 @@ describe(`editSetSlice`, () => {
         expect(editSetReducer(state, { type: `editSet/clear` })).toEqual({
           id: undefined,
           title: 'New set',
+          isProtected: false, 
           words: [],
           progress: {
             mode: 'loading',
@@ -279,6 +285,7 @@ describe(`editSetSlice`, () => {
       const fetchedState = {
         id: 'set_id',
         title: 'Loaded Set',
+        protected: false,
         words: [
           {
             id: "0_6",
@@ -294,7 +301,6 @@ describe(`editSetSlice`, () => {
         ],
       }
       
-
       it(`should set the progress to loading`, () => {
         expect(editSetReducer(state, { type: `editSet/editSet/pending` })).toEqual({
           ...state,
@@ -327,6 +333,7 @@ describe(`editSetSlice`, () => {
           },
           id: 'set_id',
           title: 'Loaded Set',
+          isProtected: false,
           words: [
             {
               id: "0_6",
@@ -337,6 +344,8 @@ describe(`editSetSlice`, () => {
                 example: 'example 6',
                 translation: 'translation 6',
               },
+              secondExample: undefined,
+              usedIn: undefined,
               error: {}
             },
           ],

--- a/src/redux/slices/edit-set/edit-set.ts
+++ b/src/redux/slices/edit-set/edit-set.ts
@@ -7,6 +7,7 @@ type State = {
   id?: string;
   title: string;
   words: WordData[];
+  isProtected: boolean;
   progress: {
     mode: 'saving' | 'loading';
     state: 'loading' | 'error' | 'success';
@@ -25,6 +26,7 @@ const DefaultState: State = {
   id: undefined,
   title: 'New set',
   words: [],
+  isProtected: false,
   progress: {
     mode: 'loading',
     state: 'loading',
@@ -200,6 +202,7 @@ const editSetSlice = createSlice({
       };
       state.id = action.payload.id;
       state.title = action.payload.title;
+      state.isProtected = action.payload.protected;
       state.words = action.payload.words.map(word => ({
         id: word.id,
         word: word.word,

--- a/src/redux/slices/edit-set/edit-set.type.ts
+++ b/src/redux/slices/edit-set/edit-set.type.ts
@@ -36,4 +36,5 @@ export type SetData = {
   id: string;
   title: string;
   words: WordData[];
+  protected: boolean;
 }


### PR DESCRIPTION
src/api/mock-server
- update set requests.
- update search requests.
- create a mock for a save-word request.

 src/redux/slices/edit-set
- add the isProtected field to the state.

src/pages/app/set/edit-set
- hide the edit-set title text field if the edit-set is protected, to prevent editing the title of the Save Word set.

 src/redux/slices/edit-set
- add the isProtected field to the state.

src/components/sets-masonry
- convert the sets property to a generic type.

src/pages/app/dictionary
- add functionality to save dictionary results.

src/pages/app/set-list
- update '/api/v1/sets/search' request
- hide the delete icon when the displayed set is protected to prevent deleting the Save Word set.