### PR TITLE
Fix the editing of the set

### DIFF
--- a/src/api/mock-server/server.ts
+++ b/src/api/mock-server/server.ts
@@ -3,10 +3,12 @@ import { mocksAuth } from './auth';
 import { mocksDiki } from './diki';
 import { mocksSets } from './sets';
 import { mocksWords } from './words';
+import { mocksUser } from './user';
 
 export const MockServer = setupServer(
   ...mocksAuth,
   ...mocksDiki,
   ...mocksSets,
-  ...mocksWords
+  ...mocksWords,
+  ...mocksUser
 )

--- a/src/api/mock-server/user.ts
+++ b/src/api/mock-server/user.ts
@@ -1,0 +1,14 @@
+import { rest } from 'msw';
+
+export const mocksUser = [
+  rest.post(`/api/v1/user/save-word`, (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({
+        status: 200,
+        message: 'success',
+      })
+    )
+  }),
+
+];

--- a/src/pages/app/set-list/set-list.tsx
+++ b/src/pages/app/set-list/set-list.tsx
@@ -13,7 +13,7 @@ import { SuperMemoPhase } from "../../../super-memo/super-memo.types";
 import { CenterPage, CreateNewSetContainer, StyledTypography } from "./set-list.styles";
 import { AnimatedIcon } from "../../../components/animated-icon/animated-icon";
 import { useAppDispatch } from "../../../redux/store";
-import { editSet } from "../../../redux/slices/edit-set/edit-set";
+import { clear, editSet } from "../../../redux/slices/edit-set/edit-set";
 import { YesNoDialog } from "../../../components/yes-no-dialog/yes-no-dialog";
 import { useYesNoDialog } from "../../../components/yes-no-dialog/use-yes-no-dialog";
 import { Loading, RegisterLoading } from "../../../components/loading/loading";
@@ -59,6 +59,11 @@ const SetList = () => {
 
   const editHandler = (item: MasonryItem) => {
     dispatch(editSet(item.id));
+    navigate(`/edit-set`);
+  }
+
+  const createSet = () => {
+    dispatch(clear());
     navigate(`/edit-set`);
   }
 
@@ -109,7 +114,7 @@ const SetList = () => {
           type="submit"
           color="primary"
           variant="contained"
-          onClick={() => navigate('/edit-set')}
+          onClick={() => createSet()}
         >New set</Button>
       </CreateNewSetContainer>
 

--- a/src/pages/app/set/view-set/view-set.tsx
+++ b/src/pages/app/set/view-set/view-set.tsx
@@ -38,7 +38,7 @@ export type WordData = {
 
 export const ViewSet = () => {
   const { setId } = useParams();
-  const [ set, setSet ] = useState<SetData>({ id: '', title: '', words: [] });
+  const [ set, setSet ] = useState<SetData>({ id: '', title: '', protected: false, words: [] });
   const [ loading, setLoading ] = useState<RegisterLoading>({ state: 'loading', message: '' });
   const matchesPC = useMediaQuery('(min-width:1024px)');
 

--- a/src/redux/slices/edit-set/edit-set.test.ts
+++ b/src/redux/slices/edit-set/edit-set.test.ts
@@ -58,7 +58,7 @@ describe(`editSetSlice`, () => {
         isProtected: false,
         progress: {
           mode: 'loading',
-          state: 'loading',
+          state: 'success',
           message: '',
         },
       });
@@ -73,7 +73,7 @@ describe(`editSetSlice`, () => {
           isProtected: false,
           progress: {
             mode: 'loading',
-            state: 'loading',
+            state: 'success',
             message: '',
           },
         });
@@ -110,7 +110,7 @@ describe(`editSetSlice`, () => {
           }],
           progress: {
             mode: 'loading',
-            state: 'loading',
+            state: 'success',
             message: '',
           },
         });
@@ -239,7 +239,7 @@ describe(`editSetSlice`, () => {
           words: [],
           progress: {
             mode: 'loading',
-            state: 'loading',
+            state: 'success',
             message: '',
           },
         });

--- a/src/redux/slices/edit-set/edit-set.ts
+++ b/src/redux/slices/edit-set/edit-set.ts
@@ -29,7 +29,7 @@ const DefaultState: State = {
   isProtected: false,
   progress: {
     mode: 'loading',
-    state: 'loading',
+    state: 'success',
     message: ''
   },
 }
@@ -148,9 +148,11 @@ const editSetSlice = createSlice({
     },
 
     clear(state) {
+      state.id  = DefaultState.id;
       state.title = DefaultState.title;
       state.words = DefaultState.words;
       state.progress = DefaultState.progress;
+      state.isProtected = DefaultState.isProtected;
     }
   },
   extraReducers: (builder) => {


### PR DESCRIPTION
src/api/mock-server/
- create a mock for the request 'api/v1/user/save-word'

src/pages/app/set-list
- modify the 'NEW SET' button click handling, it now clears the edit-set state before going to the edit-set page.

src/pages/app/set/view-set
- change the default value of the set state to fix a TypeScript error.

src/redux/slices/edit-set
- change the implementation of the clear action (fix an infinite load bug) to allow the user to create a new set